### PR TITLE
issue-138: Add the default vpc network to the redis_allowed_cidr_blocks

### DIFF
--- a/elasticache.tf
+++ b/elasticache.tf
@@ -15,7 +15,7 @@ module "elasticache" {
   automatic_failover_enabled = var.redis_automatic_failover_enabled
   engine_version             = var.redis_engine_version
   family                     = var.redis_family
-  allowed_cidr_blocks        = var.redis_allowed_cidr_blocks
+  allowed_cidr_blocks        = local.redis_allowed_cidr_blocks
   allowed_security_group_ids = var.redis_allowed_security_group_ids
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -37,7 +37,7 @@ locals {
 
   # compact function will remove null elements from list to not interfere with jsonencode afterwards
   secrets_kms_key_arns = compact([
-    length(module.rds_maindb) > 0 ? module.rds_maindb[0].rds_credentials_kms_key_arn : null ,
+    length(module.rds_maindb) > 0 ? module.rds_maindb[0].rds_credentials_kms_key_arn : null,
     length(module.elasticache) > 0 ? module.elasticache[0].redis_secret_kms_key_arn : null
   ])
 
@@ -45,6 +45,7 @@ locals {
   karpenter_namespace            = "karpenter"
   karpenter_service_account_name = "karpenter"
 
+  redis_allowed_cidr_blocks = concat(var.redis_allowed_cidr_blocks, [var.vpc_cidr])
 
 }
 


### PR DESCRIPTION
Automatically get the default vpc cidr as allowed for redis/elasticache